### PR TITLE
Fix bugs in the margin trading support of binance-s

### DIFF
--- a/exc-binance/src/http/request/listen_key.rs
+++ b/exc-binance/src/http/request/listen_key.rs
@@ -14,7 +14,8 @@ impl Rest for CurrentListenKey {
     fn to_path(&self, endpoint: &super::RestEndpoint) -> Result<String, RestError> {
         match endpoint {
             RestEndpoint::UsdMarginFutures => Ok(format!("/fapi/v1/listenKey")),
-            _ => Ok(format!("/api/v3/userDataStream")),
+            RestEndpoint::Spot(false) => Ok(format!("/api/v3/userDataStream")),
+            RestEndpoint::Spot(true) => Ok(format!("/sapi/v1/userDataStream")),
         }
     }
 

--- a/exc-binance/src/http/request/trading/mod.rs
+++ b/exc-binance/src/http/request/trading/mod.rs
@@ -1,3 +1,5 @@
+use self::spot::SideEffect;
+
 use super::{Rest, RestEndpoint, RestError};
 use serde::Serialize;
 
@@ -19,9 +21,14 @@ impl PlaceOrder {
             RestEndpoint::UsdMarginFutures => Ok(PlaceOrderKind::UsdMarginFutures(
                 usd_margin_futures::PlaceOrder::try_from(&self.inner)?,
             )),
-            RestEndpoint::Spot(_) => Ok(PlaceOrderKind::Spot(spot::PlaceOrder::try_from(
-                &self.inner,
-            )?)),
+            RestEndpoint::Spot(margin) => {
+                let mut req = spot::PlaceOrder::try_from(&self.inner)?;
+                if *margin {
+                    // FIXME: it is better to make it an option.
+                    req.side_effect_type = Some(SideEffect::MarginBuy);
+                }
+                Ok(PlaceOrderKind::Spot(req))
+            }
         }
     }
 }

--- a/exc-binance/src/http/request/trading/spot.rs
+++ b/exc-binance/src/http/request/trading/spot.rs
@@ -19,6 +19,18 @@ pub enum RespType {
     Full,
 }
 
+/// Side effect (for margin)
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SideEffect {
+    /// No side effect.
+    NoSideEffect,
+    /// Margin buy.
+    MarginBuy,
+    /// Auto repay.
+    AutoRepay,
+}
+
 /// Place order.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -42,6 +54,9 @@ pub struct PlaceOrder {
     /// Price.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price: Option<Decimal>,
+    /// Side effect (for margin).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub side_effect_type: Option<SideEffect>,
     /// Client id.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_client_order_id: Option<String>,
@@ -83,6 +98,7 @@ impl<'a> TryFrom<&'a exc_core::types::PlaceOrder> for PlaceOrder {
             price,
             new_client_order_id: req.client_id.clone(),
             time_in_force: tif,
+            side_effect_type: None,
             new_order_resp_type: Some(RespType::Ack),
         })
     }

--- a/exc-binance/src/http/response/trading.rs
+++ b/exc-binance/src/http/response/trading.rs
@@ -1,6 +1,7 @@
 use exc_core::ExchangeError;
 use rust_decimal::Decimal;
 use serde::Deserialize;
+use serde_with::serde_as;
 
 use crate::{
     http::error::RestError,
@@ -125,12 +126,14 @@ pub struct UsdMarginFuturesOrder {
 }
 
 /// Spot Ack.
+#[serde_as]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SpotAck {
     /// Symbol.
     pub symbol: String,
     /// Order id.
+    #[serde_as(as = "serde_with::PickFirst<(_, serde_with::DisplayFromStr)>")]
     pub order_id: i64,
     /// Orignal client order id.
     orig_client_order_id: Option<String>,


### PR DESCRIPTION
- Default to use `MARGIN_BUY` side effect to place order
- Fix `order_id` parsing in cancel response
- Fix `listent_key` endpoint