### PR TITLE
binance: add `stop_refreshing_after` option for ws endpoint

### DIFF
--- a/examples/binance_orders.rs
+++ b/examples/binance_orders.rs
@@ -31,7 +31,11 @@ async fn main() -> anyhow::Result<()> {
         _ => anyhow::bail!("unsupported"),
     };
 
-    let mut binance = endpoint.private(key).connect().into_exc();
+    let mut binance = endpoint
+        .private(key)
+        .ws_listen_key_stop_refreshing_after(Duration::from_secs(60))
+        .connect()
+        .into_exc();
 
     let mut revision = 0;
     loop {

--- a/exc-binance/src/endpoint.rs
+++ b/exc-binance/src/endpoint.rs
@@ -68,6 +68,12 @@ impl Endpoint {
         self
     }
 
+    /// Set listen key active stop duration.
+    pub fn ws_listen_key_stop_refreshing_after(&mut self, interval: Duration) -> &mut Self {
+        self.ws.listen_key_stop_refreshing_after(interval);
+        self
+    }
+
     /// Private mode.
     pub fn private(&mut self, key: BinanceKey) -> &mut Self {
         self.key = Some(key);

--- a/exc-binance/src/websocket/endpoint.rs
+++ b/exc-binance/src/websocket/endpoint.rs
@@ -19,6 +19,7 @@ pub struct WsEndpoint {
     default_stream_timeout: Option<Duration>,
     listen_key_retry: Option<usize>,
     listen_key_refresh_interval: Option<Duration>,
+    listen_key_stop_refreshing_after: Option<Duration>,
 }
 
 impl WsEndpoint {
@@ -35,6 +36,7 @@ impl WsEndpoint {
             default_stream_timeout: None,
             listen_key_retry: None,
             listen_key_refresh_interval: None,
+            listen_key_stop_refreshing_after: None,
         }
     }
 
@@ -59,6 +61,12 @@ impl WsEndpoint {
     /// Set listen key refresh interval.
     pub fn listen_key_refresh_interval(&mut self, interval: Duration) -> &mut Self {
         self.listen_key_refresh_interval = Some(interval);
+        self
+    }
+
+    /// Set listen key active stop duration.
+    pub fn listen_key_stop_refreshing_after(&mut self, interval: Duration) -> &mut Self {
+        self.listen_key_stop_refreshing_after = Some(interval);
         self
     }
 
@@ -91,6 +99,7 @@ impl WsEndpoint {
             default_stream_timeout,
             retry: self.listen_key_retry,
             interval: self.listen_key_refresh_interval,
+            stop_refresing_after: self.listen_key_stop_refreshing_after,
         };
         let connection = Reconnect::new::<WsClient, WsRequest>(connect, self.target.clone())
             .map_err(|err| match err.downcast::<WsError>() {


### PR DESCRIPTION
For the websocket connections of `binance-s` maybe hang up without any notification