### PR TITLE
Add `TradingService::place_with_opts` and `PlaceOrderOptions`

### DIFF
--- a/examples/examples/okx_ws_trading.rs
+++ b/examples/examples/okx_ws_trading.rs
@@ -1,6 +1,6 @@
 use exc::{
     transport::http::endpoint::Endpoint as HttpEndpoint,
-    types::trading::Place,
+    types::trading::{Place, PlaceOrderOptions},
     ExcLayer, {CheckOrderService, TradingService},
 };
 use exc_okx::{
@@ -44,7 +44,10 @@ async fn main() -> anyhow::Result<()> {
 
     let inst = "DOGE-USDT";
     let id = ws
-        .place(inst, &Place::with_size(dec!(10)).limit(dec!(0.01)), None)
+        .place_with_opts(
+            &Place::with_size(dec!(10)).limit(dec!(0.01)),
+            &PlaceOrderOptions::new(inst),
+        )
         .await?
         .id;
     tracing::info!("id={id:?}");

--- a/examples/examples/okx_ws_trading_testing.rs
+++ b/examples/examples/okx_ws_trading_testing.rs
@@ -1,6 +1,6 @@
 use exc::{
     transport::http::endpoint::Endpoint as HttpEndpoint,
-    types::trading::Place,
+    types::trading::{Place, PlaceOrderOptions},
     ExcLayer, {CheckOrderService, TradingService},
 };
 use exc_okx::{
@@ -45,7 +45,10 @@ async fn main() -> anyhow::Result<()> {
 
     let inst = "DOGE-USDT";
     let id = ws
-        .place(inst, &Place::with_size(dec!(10)).limit(dec!(0.01)), None)
+        .place_with_opts(
+            &Place::with_size(dec!(10)).post_only(dec!(0.01)),
+            &PlaceOrderOptions::new(inst),
+        )
         .await?
         .id;
     tracing::info!("id={id:?}");

--- a/examples/examples/okx_ws_trading_testing.rs
+++ b/examples/examples/okx_ws_trading_testing.rs
@@ -47,7 +47,7 @@ async fn main() -> anyhow::Result<()> {
     let id = ws
         .place_with_opts(
             &Place::with_size(dec!(10)).post_only(dec!(0.01)),
-            &PlaceOrderOptions::new(inst),
+            PlaceOrderOptions::new(inst).insert("tdMode", "cash"),
         )
         .await?
         .id;

--- a/exc-binance/src/http/request/trading/spot.rs
+++ b/exc-binance/src/http/request/trading/spot.rs
@@ -90,13 +90,13 @@ impl<'a> TryFrom<&'a exc_core::types::PlaceOrder> for PlaceOrder {
             types::OrderKind::PostOnly(price) => (OrderType::LimitMaker, Some(price), None),
         };
         Ok(Self {
-            symbol: req.opts.instrument.to_uppercase(),
+            symbol: req.opts.instrument().to_uppercase(),
             side,
             order_type,
             quantity: Some(place.size.abs()),
             quote_order_qty: None,
             price,
-            new_client_order_id: req.opts.client_id.clone(),
+            new_client_order_id: req.opts.client_id().map(|s| s.to_string()),
             time_in_force: tif,
             side_effect_type: None,
             new_order_resp_type: Some(RespType::Ack),

--- a/exc-binance/src/http/request/trading/spot.rs
+++ b/exc-binance/src/http/request/trading/spot.rs
@@ -90,13 +90,13 @@ impl<'a> TryFrom<&'a exc_core::types::PlaceOrder> for PlaceOrder {
             types::OrderKind::PostOnly(price) => (OrderType::LimitMaker, Some(price), None),
         };
         Ok(Self {
-            symbol: req.instrument.to_uppercase(),
+            symbol: req.opts.instrument.to_uppercase(),
             side,
             order_type,
             quantity: Some(place.size.abs()),
             quote_order_qty: None,
             price,
-            new_client_order_id: req.client_id.clone(),
+            new_client_order_id: req.opts.client_id.clone(),
             time_in_force: tif,
             side_effect_type: None,
             new_order_resp_type: Some(RespType::Ack),

--- a/exc-binance/src/http/request/trading/usd_margin_futures.rs
+++ b/exc-binance/src/http/request/trading/usd_margin_futures.rs
@@ -98,14 +98,14 @@ impl<'a> TryFrom<&'a types::PlaceOrder> for PlaceOrder {
             }
         };
         Ok(Self {
-            symbol: req.instrument.to_uppercase(),
+            symbol: req.opts.instrument.to_uppercase(),
             side,
             position_side: PositionSide::Both,
             order_type,
             reduce_only: None,
             quantity: Some(place.size.abs()),
             price,
-            new_client_order_id: req.client_id.clone(),
+            new_client_order_id: req.opts.client_id.clone(),
             stop_price: None,
             close_position: None,
             activation_price: None,

--- a/exc-binance/src/http/request/trading/usd_margin_futures.rs
+++ b/exc-binance/src/http/request/trading/usd_margin_futures.rs
@@ -98,14 +98,14 @@ impl<'a> TryFrom<&'a types::PlaceOrder> for PlaceOrder {
             }
         };
         Ok(Self {
-            symbol: req.opts.instrument.to_uppercase(),
+            symbol: req.opts.instrument().to_uppercase(),
             side,
             position_side: PositionSide::Both,
             order_type,
             reduce_only: None,
             quantity: Some(place.size.abs()),
             price,
-            new_client_order_id: req.opts.client_id.clone(),
+            new_client_order_id: req.opts.client_id().map(|s| s.to_string()),
             stop_price: None,
             close_position: None,
             activation_price: None,

--- a/exc-core/src/types/trading/mod.rs
+++ b/exc-core/src/types/trading/mod.rs
@@ -4,7 +4,7 @@ pub mod place;
 /// Order.
 pub mod order;
 
-use std::{fmt, sync::Arc};
+use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use futures::{future::BoxFuture, stream::BoxStream};
 pub use order::{Order, OrderId, OrderKind, OrderState, OrderStatus, OrderTrade, TimeInForce};
@@ -17,11 +17,13 @@ use crate::{ExchangeError, Request};
 #[derive(Debug, Clone)]
 pub struct PlaceOrderOptions {
     /// Instrument.
-    pub instrument: String,
+    instrument: String,
     /// Client id.
-    pub client_id: Option<String>,
+    client_id: Option<String>,
     /// Margin currency perferred to use.
-    pub margin: Option<String>,
+    margin: Option<String>,
+    /// Exchange-defined options.
+    custom: BTreeMap<String, String>,
 }
 
 impl PlaceOrderOptions {
@@ -31,6 +33,7 @@ impl PlaceOrderOptions {
             instrument: inst.to_string(),
             client_id: None,
             margin: None,
+            custom: BTreeMap::default(),
         }
     }
 
@@ -47,6 +50,26 @@ impl PlaceOrderOptions {
     pub fn with_margin(&mut self, currency: &str) -> &mut Self {
         self.margin = Some(currency.to_string());
         self
+    }
+
+    /// Get the instrument name to trade.
+    pub fn instrument(&self) -> &str {
+        &self.instrument
+    }
+
+    /// Get the client id to use.
+    pub fn client_id(&self) -> Option<&str> {
+        self.client_id.as_deref()
+    }
+
+    /// Get the margin currency perferred to use.
+    pub fn margin(&self) -> Option<&str> {
+        self.margin.as_deref()
+    }
+
+    /// Get the exchange-defined custom options.
+    pub fn custom(&self) -> &BTreeMap<String, String> {
+        &self.custom
     }
 }
 

--- a/exc-core/src/types/trading/mod.rs
+++ b/exc-core/src/types/trading/mod.rs
@@ -4,7 +4,7 @@ pub mod place;
 /// Order.
 pub mod order;
 
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use futures::{future::BoxFuture, stream::BoxStream};
 pub use order::{Order, OrderId, OrderKind, OrderState, OrderStatus, OrderTrade, TimeInForce};
@@ -13,15 +13,48 @@ use time::OffsetDateTime;
 
 use crate::{ExchangeError, Request};
 
+/// Options for order placement.
+#[derive(Debug, Clone)]
+pub struct PlaceOrderOptions {
+    /// Instrument.
+    pub instrument: String,
+    /// Client id.
+    pub client_id: Option<String>,
+}
+
+impl PlaceOrderOptions {
+    /// Create a new options with the given instrument.
+    pub fn new(inst: &str) -> Self {
+        Self {
+            instrument: inst.to_string(),
+            client_id: None,
+        }
+    }
+
+    /// Set the client id to place.
+    pub fn with_client_id(&mut self, id: Option<&str>) -> &mut Self {
+        self.client_id = id.map(|s| s.to_string());
+        self
+    }
+}
+
 /// Place order.
 #[derive(Debug, Clone)]
 pub struct PlaceOrder {
-    /// Instrument.
-    pub instrument: String,
     /// Place.
     pub place: Place,
-    /// Client id.
-    pub client_id: Option<String>,
+    /// Options.
+    pub opts: Arc<PlaceOrderOptions>,
+}
+
+impl PlaceOrder {
+    /// Create a new request to place order.
+    pub fn new(place: Place, opts: &PlaceOrderOptions) -> Self {
+        Self {
+            place,
+            opts: Arc::new(opts.clone()),
+        }
+    }
 }
 
 /// Place order response.

--- a/exc-core/src/types/trading/mod.rs
+++ b/exc-core/src/types/trading/mod.rs
@@ -20,6 +20,8 @@ pub struct PlaceOrderOptions {
     pub instrument: String,
     /// Client id.
     pub client_id: Option<String>,
+    /// Margin currency perferred to use.
+    pub margin: Option<String>,
 }
 
 impl PlaceOrderOptions {
@@ -28,12 +30,22 @@ impl PlaceOrderOptions {
         Self {
             instrument: inst.to_string(),
             client_id: None,
+            margin: None,
         }
     }
 
     /// Set the client id to place.
     pub fn with_client_id(&mut self, id: Option<&str>) -> &mut Self {
         self.client_id = id.map(|s| s.to_string());
+        self
+    }
+
+    /// Set the margin currency preffered to use.
+    /// # Warning
+    /// It is up to the exchange to decide if this option applies,
+    /// so please check the documents of the exchange you use.
+    pub fn with_margin(&mut self, currency: &str) -> &mut Self {
+        self.margin = Some(currency.to_string());
         self
     }
 }

--- a/exc-core/src/types/trading/mod.rs
+++ b/exc-core/src/types/trading/mod.rs
@@ -52,6 +52,17 @@ impl PlaceOrderOptions {
         self
     }
 
+    /// Insert an exchange-defined custom option.
+    pub fn insert<K, V>(&mut self, key: K, value: V) -> &mut Self
+    where
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        self.custom
+            .insert(key.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
     /// Get the instrument name to trade.
     pub fn instrument(&self) -> &str {
         &self.instrument

--- a/exc-core/src/types/trading/place.rs
+++ b/exc-core/src/types/trading/place.rs
@@ -1,4 +1,4 @@
-use super::{order::TimeInForce, OrderKind};
+use super::{order::TimeInForce, OrderKind, PlaceOrder, PlaceOrderOptions};
 use rust_decimal::Decimal;
 
 /// A [`Place`] describes how exchange build an order, i.e. the order builder.
@@ -36,5 +36,10 @@ impl Place {
     pub fn post_only(mut self, price: Decimal) -> Self {
         self.kind = OrderKind::PostOnly(price);
         self
+    }
+
+    /// Build the [`PlaceOrder`] request.
+    pub fn into_request(self, opts: &PlaceOrderOptions) -> PlaceOrder {
+        PlaceOrder::new(self, opts)
     }
 }

--- a/exc-okx/src/http/types/adaptations/trading.rs
+++ b/exc-okx/src/http/types/adaptations/trading.rs
@@ -1,7 +1,7 @@
 use exc_core::{
     types::{
         trading::{GetOrder, Order as ExcOrder, OrderId, OrderState, OrderStatus, Place},
-        OrderUpdate,
+        OrderUpdate, TimeInForce,
     },
     Adaptor, ExchangeError,
 };
@@ -57,6 +57,33 @@ impl Adaptor<GetOrder> for HttpRequest {
                             } else {
                                 return Err(ExchangeError::Other(anyhow::anyhow!(
                                     "limit without price"
+                                )));
+                            }
+                        }
+                        "fok" => {
+                            if let Some(price) = order.price {
+                                target.limit_with_tif(price, TimeInForce::FillOrKill)
+                            } else {
+                                return Err(ExchangeError::Other(anyhow::anyhow!(
+                                    "fok without price"
+                                )));
+                            }
+                        }
+                        "ioc" => {
+                            if let Some(price) = order.price {
+                                target.limit_with_tif(price, TimeInForce::ImmediateOrCancel)
+                            } else {
+                                return Err(ExchangeError::Other(anyhow::anyhow!(
+                                    "ioc without price"
+                                )));
+                            }
+                        }
+                        "post_only" => {
+                            if let Some(price) = order.price {
+                                target.post_only(price)
+                            } else {
+                                return Err(ExchangeError::Other(anyhow::anyhow!(
+                                    "post_only without price"
                                 )));
                             }
                         }

--- a/exc-okx/src/websocket/adaptations.rs
+++ b/exc-okx/src/websocket/adaptations.rs
@@ -79,7 +79,7 @@ impl Adaptor<PlaceOrder> for Request {
     where
         Self: Sized,
     {
-        Ok(Self::order(&req.instrument, &req.place))
+        Ok(Self::order(&req.opts.instrument, &req.place))
     }
 
     fn into_response(

--- a/exc-okx/src/websocket/adaptations.rs
+++ b/exc-okx/src/websocket/adaptations.rs
@@ -79,7 +79,7 @@ impl Adaptor<PlaceOrder> for Request {
     where
         Self: Sized,
     {
-        Ok(Self::order(&req.opts.instrument, &req.place))
+        Ok(Self::order(&req))
     }
 
     fn into_response(

--- a/exc-okx/src/websocket/types/messages/request.rs
+++ b/exc-okx/src/websocket/types/messages/request.rs
@@ -111,7 +111,7 @@ impl WsRequest {
 
     /// Order request.
     pub(crate) fn order(place: &Place, opts: &PlaceOrderOptions) -> Self {
-        let inst = opts.instrument.as_str();
+        let inst = opts.instrument();
         let size = place.size.abs();
         let side = if place.size.is_sign_negative() {
             "sell"
@@ -125,7 +125,7 @@ impl WsRequest {
             ("posSide".to_string(), "net".to_string()),
             ("sz".to_string(), size.to_string()),
         ]);
-        if let Some(margin) = opts.margin.as_ref() {
+        if let Some(margin) = opts.margin() {
             map.insert("ccy".to_string(), margin.to_string());
         }
         match place.kind {

--- a/exc-okx/src/websocket/types/messages/request.rs
+++ b/exc-okx/src/websocket/types/messages/request.rs
@@ -112,6 +112,7 @@ impl WsRequest {
     /// Order request.
     pub(crate) fn order(place: &Place, opts: &PlaceOrderOptions) -> Self {
         let inst = opts.instrument();
+        let custom = opts.custom();
         let size = place.size.abs();
         let side = if place.size.is_sign_negative() {
             "sell"
@@ -120,7 +121,14 @@ impl WsRequest {
         };
         let mut map = BTreeMap::from([
             ("instId".to_string(), inst.to_string()),
-            ("tdMode".to_string(), "cross".to_string()),
+            (
+                "tdMode".to_string(),
+                custom
+                    .get("tdMode")
+                    .map(|s| s.as_str())
+                    .unwrap_or("cross")
+                    .to_string(),
+            ),
             ("side".to_string(), side.to_string()),
             ("posSide".to_string(), "net".to_string()),
             ("sz".to_string(), size.to_string()),

--- a/exc-okx/src/websocket/types/request.rs
+++ b/exc-okx/src/websocket/types/request.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use async_stream::stream;
 use exc_core::{
-    types::{ticker::SubscribeTickers, trading::Place},
+    types::{ticker::SubscribeTickers, PlaceOrder},
     ExchangeError,
 };
 use futures::stream::{BoxStream, StreamExt};
@@ -65,12 +65,12 @@ impl Request {
     }
 
     /// Order request.
-    pub fn order(inst: &str, place: &Place) -> Self {
+    pub fn order(req: &PlaceOrder) -> Self {
         let (cb, _rx) = Callback::new();
-        let inst = inst.to_string();
-        let place = *place;
+        let opts = req.opts.clone();
+        let place = req.place;
         let stream = stream! {
-            yield ClientFrame { stream_id: 0, inner: WsRequest::order(&inst, &place) };
+            yield ClientFrame { stream_id: 0, inner: WsRequest::order(&place, &opts) };
             // let _ = rx.await;
         };
 


### PR DESCRIPTION
With the help of `PlaceOrderOptions`, we can now provide more information to guide the exchange library to construct order placement requests.

For example, we can now use the following code to specify the margin currency to use in a margin order (for the supported exchanges):
```rust
// okx: impl TradingService
let res = okx
    .place_with_opts(
        &Place::with_size(dec!(10)).limit(dec!(0.01)),
        PlaceOrderOptions::new("DOGE-USDT").margin("DOGE"),
    )
    .await?;
```

This should fix #15 when placing a margin order under the "single currency margin" mode in OKX.