### PR TITLE
Refine the "adaptor" API with a new `AdaptService` trait

### DIFF
--- a/exc-core/Cargo.toml
+++ b/exc-core/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 native-tls = ["tokio-tungstenite?/native-tls", "hyper-tls"]
 rustls-tls = ["tokio-tungstenite?/rustls-tls-webpki-roots", "hyper-rustls"]
 websocket = ["tokio-tungstenite", "dep:http", "tokio/net"]
-driven = ["tokio/sync", "tokio/rt", "pin-project-lite"]
+driven = ["tokio/sync", "tokio/rt"]
 http = ["hyper/client", "hyper/http1", "dep:http"]
 retry = ["tower/retry", "tokio/time", "humantime"]
 
@@ -41,6 +41,7 @@ num-traits = { workspace = true }
 positions = { workspace = true, features = ["serde"] }
 either = { workspace = true }
 tokio-stream = { workspace = true }
+pin-project-lite = { workspace = true }
 humantime = { workspace = true, optional = true }
 derive_more = "0.99"
 
@@ -53,10 +54,6 @@ workspace = true
 optional = true
 
 [dependencies.tokio]
-workspace = true
-optional = true
-
-[dependencies.pin-project-lite]
 workspace = true
 optional = true
 

--- a/exc-core/src/lib.rs
+++ b/exc-core/src/lib.rs
@@ -27,5 +27,5 @@ pub mod symbol {
 }
 
 pub use self::error::ExchangeError;
-pub use self::service::{Adaptor, Exc, ExcLayer, ExcService, IntoExc, Request};
+pub use self::service::{Adaptor, Exc, ExcLayer, ExcService, ExcServiceExt, IntoExc, Request};
 pub use positions::prelude::{Asset, Instrument, ParseAssetError, ParseSymbolError, Str, Symbol};

--- a/exc-core/src/service/adapt.rs
+++ b/exc-core/src/service/adapt.rs
@@ -1,9 +1,39 @@
-use std::marker::PhantomData;
+use std::{fmt, future::Future, marker::PhantomData};
 
-use futures::{future::BoxFuture, FutureExt};
+use futures::TryFuture;
+use pin_project_lite::pin_project;
 use tower::{Layer, Service};
 
-use crate::{Adaptor, ExcService, ExchangeError, Request};
+use crate::{ExcService, ExchangeError, Request};
+
+/// An adaptor for request.
+pub trait Adaptor<R: Request>: Request {
+    /// Convert from request.
+    fn from_request(req: R) -> Result<Self, ExchangeError>;
+
+    /// Convert into response.
+    fn into_response(resp: Self::Response) -> Result<R::Response, ExchangeError>;
+}
+
+impl<T, R, E> Adaptor<R> for T
+where
+    T: Request,
+    R: Request,
+    T: TryFrom<R, Error = E>,
+    T::Response: TryInto<R::Response, Error = E>,
+    ExchangeError: From<E>,
+{
+    fn from_request(req: R) -> Result<Self, ExchangeError>
+    where
+        Self: Sized,
+    {
+        Ok(Self::try_from(req)?)
+    }
+
+    fn into_response(resp: Self::Response) -> Result<<R as Request>::Response, ExchangeError> {
+        Ok(resp.try_into()?)
+    }
+}
 
 /// Layer for creating [`Adapted`].
 #[derive(Debug)]
@@ -16,34 +46,178 @@ impl<Req, R> Default for AdaptLayer<Req, R> {
 }
 
 impl<S, Req, R> Layer<S> for AdaptLayer<Req, R> {
-    type Service = Adapted<S, Req, R>;
+    type Service = Adapt<S, Req, R>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        Adapted(inner, PhantomData)
+        Adapt(inner, PhantomData)
     }
 }
 
-/// Convert the inner service to be a service of the target request.
-#[derive(Debug)]
-pub struct Adapted<S, Req, R>(S, PhantomData<fn() -> (Req, R)>);
+/// Service that can handle request [`R`] with its inner request [`Req`].
+pub trait AdaptService<Req, R>: ExcService<Req>
+where
+    Req: Request,
+    R: Request,
+{
+    /// Future returned by [`AdaptService::into_response`].
+    type AdaptedResponse: Future<Output = Result<R::Response, ExchangeError>>;
 
-impl<S: Clone, Req, R> Clone for Adapted<S, Req, R> {
+    /// Adapt the request.
+    fn from_request(&mut self, req: R) -> Result<Req, ExchangeError>;
+
+    /// Adapt the response future
+    fn into_response(&mut self, res: Self::Future) -> Self::AdaptedResponse;
+}
+
+pin_project! {
+    /// Future for [`AdaptService`] implementation.
+    #[derive(Debug)]
+    pub struct AndThen<Fut, F> {
+        #[pin]
+        fut: Fut,
+        f: Option<F>,
+    }
+}
+
+impl<Fut, F> AndThen<Fut, F>
+where
+    Fut: TryFuture<Error = ExchangeError>,
+{
+    /// Create a new [`AndThen`] future.
+    pub fn new(fut: Fut, f: F) -> Self {
+        Self { fut, f: Some(f) }
+    }
+}
+
+impl<Fut, F, T> Future for AndThen<Fut, F>
+where
+    Fut: TryFuture<Error = ExchangeError>,
+    F: FnOnce(Fut::Ok) -> Result<T, ExchangeError>,
+{
+    type Output = Result<T, ExchangeError>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        match this.fut.try_poll(cx) {
+            std::task::Poll::Ready(Ok(ok)) => match this.f.take() {
+                Some(f) => std::task::Poll::Ready((f)(ok)),
+                None => return std::task::Poll::Pending,
+            },
+            std::task::Poll::Ready(Err(err)) => std::task::Poll::Ready(Err(err)),
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
+}
+
+impl<C, Req, R> AdaptService<Req, R> for C
+where
+    Req: Request,
+    R: Request,
+    Req: Adaptor<R>,
+    C: ExcService<Req>,
+{
+    type AdaptedResponse =
+        AndThen<Self::Future, fn(Req::Response) -> Result<R::Response, ExchangeError>>;
+
+    fn from_request(&mut self, req: R) -> Result<Req, ExchangeError> {
+        Req::from_request(req)
+    }
+
+    fn into_response(&mut self, res: Self::Future) -> Self::AdaptedResponse {
+        AndThen::new(res, Req::into_response)
+    }
+}
+
+/// Adapt Service Wrapper.
+pub struct Adapt<C, Req, R>(C, PhantomData<fn() -> (Req, R)>);
+
+impl<C, Req, R> fmt::Debug for Adapt<C, Req, R>
+where
+    C: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Adapt")
+            .field(&self.0)
+            .field(&self.1)
+            .finish()
+    }
+}
+
+impl<C, Req, R> Clone for Adapt<C, Req, R>
+where
+    C: Clone,
+{
     fn clone(&self) -> Self {
         Self(self.0.clone(), PhantomData)
     }
 }
 
-impl<C, Req, R> Service<R> for Adapted<C, Req, R>
+impl<C, Req, R> Copy for Adapt<C, Req, R> where C: Copy {}
+
+pin_project! {
+    /// Future returned by [`Adapt`].
+    #[allow(missing_docs)]
+    #[project = AdaptProj]
+    #[derive(Debug)]
+    pub enum AdaptFuture<Fut> {
+        /// From request error.
+        FromRequestError {
+            err: Option<ExchangeError>,
+        },
+        /// Into response.
+        IntoResponse {
+            #[pin]
+            fut: Fut,
+        }
+    }
+}
+
+impl<Fut> AdaptFuture<Fut> {
+    /// Create a new [`AdaptFuture::FromRequestError`].
+    pub fn from_request_error(err: ExchangeError) -> Self {
+        Self::FromRequestError { err: Some(err) }
+    }
+
+    /// Create a new [`AdaptFuture::IntoResponse`].
+    pub fn into_response(fut: Fut) -> Self {
+        Self::IntoResponse { fut }
+    }
+}
+
+impl<Fut> Future for AdaptFuture<Fut>
 where
+    Fut: TryFuture<Error = ExchangeError>,
+{
+    type Output = Result<Fut::Ok, ExchangeError>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match self.as_mut().project() {
+            AdaptProj::FromRequestError { err } => match err.take() {
+                Some(err) => std::task::Poll::Ready(Err(err)),
+                None => std::task::Poll::Pending,
+            },
+            AdaptProj::IntoResponse { fut, .. } => fut.try_poll(cx),
+        }
+    }
+}
+
+impl<C, Req, R> Service<R> for Adapt<C, Req, R>
+where
+    C: AdaptService<Req, R>,
+    Req: Request,
     R: Request,
-    R::Response: Send + 'static,
-    Req: Adaptor<R>,
-    C: ExcService<Req>,
-    C::Future: Send + 'static,
 {
     type Response = R::Response;
+
     type Error = ExchangeError;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    type Future = AdaptFuture<C::AdaptedResponse>;
 
     fn poll_ready(
         &mut self,
@@ -53,19 +227,11 @@ where
     }
 
     fn call(&mut self, req: R) -> Self::Future {
-        let request = Req::from_request(req);
-        match request {
-            Ok(req) => {
-                let res = self.0.call(req);
-                async move {
-                    let resp = res.await?;
-                    let resp = Req::into_response(resp)?;
-                    Ok(resp)
-                }
-                .left_future()
-            }
-            Err(err) => futures::future::ready(Err(err)).right_future(),
-        }
-        .boxed()
+        let req = match self.0.from_request(req) {
+            Ok(req) => req,
+            Err(err) => return AdaptFuture::from_request_error(err),
+        };
+        let res = self.0.call(req);
+        AdaptFuture::into_response(self.0.into_response(res))
     }
 }

--- a/exc-core/src/service/mod.rs
+++ b/exc-core/src/service/mod.rs
@@ -17,9 +17,12 @@ pub mod traits;
 pub mod adapt;
 
 pub use layer::ExcLayer;
-pub use traits::{Adaptor, ExcService, IntoExc, Request};
+pub use {
+    adapt::Adaptor,
+    traits::{ExcService, IntoExc, Request},
+};
 
-use self::adapt::{AdaptLayer, Adapted};
+use self::adapt::{Adapt, AdaptLayer, AdaptService};
 
 /// The core service wrapper of this crate, which implements
 /// [`ExcService<T>`] *if* the request type of the underlying
@@ -99,12 +102,10 @@ where
     }
 
     /// Adapt the request type of the underlying channel to the target type `R`.
-    pub fn into_adapted<R>(self) -> Exc<Adapted<C, Req, R>, R>
+    pub fn into_adapted<R>(self) -> Exc<Adapt<C, Req, R>, R>
     where
         R: Request,
-        R::Response: Send + 'static,
-        Req: Adaptor<R>,
-        C::Future: Send + 'static,
+        C: AdaptService<Req, R>,
     {
         self.into_layered(&AdaptLayer::default())
     }

--- a/exc-core/src/service/mod.rs
+++ b/exc-core/src/service/mod.rs
@@ -19,7 +19,7 @@ pub mod adapt;
 pub use layer::ExcLayer;
 pub use {
     adapt::Adaptor,
-    traits::{ExcService, IntoExc, Request},
+    traits::{ExcService, ExcServiceExt, IntoExc, Request},
 };
 
 use self::adapt::{Adapt, AdaptLayer, AdaptService};

--- a/exc-core/src/service/traits.rs
+++ b/exc-core/src/service/traits.rs
@@ -16,6 +16,20 @@ pub trait ExcService<R>: Service<R, Response = R::Response, Error = ExchangeErro
 where
     R: Request,
 {
+}
+
+impl<S, R> ExcService<R> for S
+where
+    S: Service<R, Response = R::Response, Error = ExchangeError>,
+    R: Request,
+{
+}
+
+/// Extension trait for [`ExcService`].
+pub trait ExcServiceExt<R>: ExcService<R>
+where
+    R: Request,
+{
     /// Apply a layer of which the result service is still a [`ExcService`].
     fn apply<L, R2>(self, layer: &L) -> L::Service
     where
@@ -38,9 +52,9 @@ where
     }
 }
 
-impl<S, R> ExcService<R> for S
+impl<S, R> ExcServiceExt<R> for S
 where
-    S: Service<R, Response = R::Response, Error = ExchangeError>,
+    S: ExcService<R>,
     R: Request,
 {
 }

--- a/exc/src/lib.rs
+++ b/exc/src/lib.rs
@@ -28,7 +28,7 @@ pub use util::{
 pub mod prelude {
     pub use crate::core::{
         types::{Period, Place, PlaceOrderOptions},
-        Adaptor, Exc, ExcService, ExchangeError, Request,
+        Adaptor, Exc, ExcService, ExcServiceExt, ExchangeError, Request,
     };
     pub use crate::util::{
         book::SubscribeBidAskService,


### PR DESCRIPTION
We use the following `AdaptService` trait to extend the original `Adaptor` trait:
```rust
/// Service that can handle request [`R`] with its inner request [`Req`].
pub trait AdaptService<Req, R>: ExcService<Req>
where
    Req: Request,
    R: Request,
{
    /// Future returned by [`AdaptService::into_response`].
    type AdaptedResponse: Future<Output = Result<R::Response, ExchangeError>>;

    /// Adapt the request.
    fn from_request(&mut self, req: R) -> Result<Req, ExchangeError>;

    /// Adapt the response future
    fn into_response(&mut self, res: Self::Future) -> Self::AdaptedResponse;
}
```
With `AdaptService`, we can now be able to insert extra information from a concrete exchange service into the request.