### PR TITLE
Redefine `ExcService` and add `SendExcService`

### DIFF
--- a/examples/examples/box_exc_service.rs
+++ b/examples/examples/box_exc_service.rs
@@ -2,7 +2,10 @@ use std::{ops::RangeBounds, str::FromStr, time::Duration};
 
 use clap::Parser;
 use exc::{
-    core::types::{Candle, SubscribeTickers, SubscribeTrades, Ticker, Trade},
+    core::{
+        types::{Candle, SubscribeTickers, SubscribeTrades, Ticker, Trade},
+        IntoService,
+    },
     prelude::*,
     types::instrument::InstrumentMeta,
     util::instrument::PollInstrumentsLayer,
@@ -48,7 +51,7 @@ impl Exchange {
         let trade_svc =
             exc::Okx::endpoint()
                 .connect_exc()
-                .into_layered(&layer_fn(|svc: exc::Okx| {
+                .into_layered(&layer_fn(|svc: IntoService<_, _>| {
                     svc
                         // We use the `adapt` method to convert the request type to `SubscribeTickers`.
                         .adapt::<SubscribeTickers>()

--- a/exc-core/src/lib.rs
+++ b/exc-core/src/lib.rs
@@ -2,9 +2,6 @@
 
 #![deny(missing_docs)]
 
-/// Core services.
-pub use exc_service as service;
-
 /// The definition of an exchange.
 pub mod exchange;
 
@@ -28,5 +25,6 @@ pub use self::service::{
     traits::{AsService, IntoService},
     Adaptor, Exc, ExcLayer, ExcService, ExcServiceExt, IntoExc, Request,
 };
-pub use exc_service::{error::InstrumentError, ExchangeError, SendExcService};
+pub use exc_service::{self as service, error::InstrumentError, ExchangeError, SendExcService};
+
 pub use positions::prelude::{Asset, Instrument, ParseAssetError, ParseSymbolError, Str, Symbol};

--- a/exc-core/src/lib.rs
+++ b/exc-core/src/lib.rs
@@ -28,5 +28,5 @@ pub use self::service::{
     traits::{AsService, IntoService},
     Adaptor, Exc, ExcLayer, ExcService, ExcServiceExt, IntoExc, Request,
 };
-pub use exc_service::{error::InstrumentError, ExchangeError};
+pub use exc_service::{error::InstrumentError, ExchangeError, SendExcService};
 pub use positions::prelude::{Asset, Instrument, ParseAssetError, ParseSymbolError, Str, Symbol};

--- a/exc-core/src/lib.rs
+++ b/exc-core/src/lib.rs
@@ -24,6 +24,9 @@ pub mod util;
 /// Exc Symbol.
 pub use exc_symbol as symbol;
 
-pub use self::service::{Adaptor, Exc, ExcLayer, ExcService, ExcServiceExt, IntoExc, Request};
+pub use self::service::{
+    traits::{AsService, IntoService},
+    Adaptor, Exc, ExcLayer, ExcService, ExcServiceExt, IntoExc, Request,
+};
 pub use exc_service::{error::InstrumentError, ExchangeError};
 pub use positions::prelude::{Asset, Instrument, ParseAssetError, ParseSymbolError, Str, Symbol};

--- a/exc-core/src/util/poll_instruments.rs
+++ b/exc-core/src/util/poll_instruments.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use async_stream::stream;
-use exc_service::{ExcService, ExchangeError};
+use exc_service::{ExcService, ExcServiceExt, ExchangeError};
 use exc_types::{FetchInstruments, SubscribeInstruments};
 use futures::{
     future::{ready, Ready},
@@ -46,7 +46,12 @@ where
                 interval.tick().await;
             }
         };
-        let stream = self.inner.clone().call_all(req).try_flatten();
+        let stream = self
+            .inner
+            .clone()
+            .into_service()
+            .call_all(req)
+            .try_flatten();
         ready(Ok(stream.boxed()))
     }
 }

--- a/exc-core/src/util/trade_bid_ask.rs
+++ b/exc-core/src/util/trade_bid_ask.rs
@@ -52,20 +52,20 @@ where
     S: Clone + Send + 'static,
     S: ExcService<SubscribeTrades>,
     S: ExcService<SubscribeBidAsk>,
-    <S as Service<SubscribeTrades>>::Future: Send,
-    <S as Service<SubscribeBidAsk>>::Future: Send,
+    <S as ExcService<SubscribeTrades>>::Future: Send,
+    <S as ExcService<SubscribeBidAsk>>::Future: Send,
 {
     type Response = TickerStream;
     type Error = ExchangeError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Service::<SubscribeTrades>::poll_ready(&mut self.svc, cx)
+        Service::<SubscribeTrades>::poll_ready(&mut self.svc.as_service(), cx)
     }
 
     fn call(&mut self, req: SubscribeTickers) -> Self::Future {
         let trade = Service::<SubscribeTrades>::call(
-            &mut self.svc,
+            &mut self.svc.as_service(),
             SubscribeTrades {
                 instrument: req.instrument.clone(),
             },

--- a/exc-make/Cargo.toml
+++ b/exc-make/Cargo.toml
@@ -11,7 +11,7 @@ description.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-exc-service = { workspace = true }
+exc-service = { workspace = true, features = ["send"] }
 exc-types = { workspace = true }
 futures = { workspace = true }
 tower-make = { workspace = true }

--- a/exc-make/src/cancel.rs
+++ b/exc-make/src/cancel.rs
@@ -1,4 +1,4 @@
-use exc_service::{ExcService, ExchangeError, Request};
+use exc_service::{ExchangeError, Request, SendExcService};
 use exc_types::CancelOrder;
 use futures::{future::MapErr, TryFutureExt};
 use std::{
@@ -14,7 +14,7 @@ pub struct MakeCancelOrderOptions {}
 /// Make a service to cancel orders.
 pub trait MakeCancelOrder {
     /// Service to cancel orders.
-    type Service: ExcService<CancelOrder>;
+    type Service: SendExcService<CancelOrder>;
 
     /// The future of the service.
     type Future: Future<Output = Result<Self::Service, ExchangeError>>;
@@ -42,7 +42,7 @@ where
         Response = <CancelOrder as Request>::Response,
         Error = ExchangeError,
     >,
-    M::Service: ExcService<CancelOrder>,
+    M::Service: SendExcService<CancelOrder>,
     M::MakeError: Into<ExchangeError>,
 {
     type Service = M::Service;

--- a/exc-make/src/candles.rs
+++ b/exc-make/src/candles.rs
@@ -1,4 +1,4 @@
-use exc_service::{ExcService, ExchangeError, Request};
+use exc_service::{ExchangeError, Request, SendExcService};
 use exc_types::QueryCandles;
 use futures::{future::MapErr, TryFutureExt};
 use std::{
@@ -19,7 +19,7 @@ pub struct MakeFetchCandlesOptions {
 /// Make a service to subscribe instruments.
 pub trait MakeFetchCandles {
     /// Service to fetch candles.
-    type Service: ExcService<QueryCandles>;
+    type Service: SendExcService<QueryCandles>;
 
     /// The future of the service.
     type Future: Future<Output = Result<Self::Service, ExchangeError>>;
@@ -47,7 +47,7 @@ where
         Response = <QueryCandles as Request>::Response,
         Error = ExchangeError,
     >,
-    M::Service: ExcService<QueryCandles>,
+    M::Service: SendExcService<QueryCandles>,
     M::MakeError: Into<ExchangeError>,
 {
     type Service = M::Service;

--- a/exc-make/src/check.rs
+++ b/exc-make/src/check.rs
@@ -1,4 +1,4 @@
-use exc_service::{ExcService, ExchangeError, Request};
+use exc_service::{ExchangeError, Request, SendExcService};
 use exc_types::GetOrder;
 use futures::{future::MapErr, TryFutureExt};
 use std::{
@@ -14,7 +14,7 @@ pub struct MakeCheckOrderOptions {}
 /// Make a service to check orders.
 pub trait MakeCheckOrder {
     /// Service to check orders.
-    type Service: ExcService<GetOrder>;
+    type Service: SendExcService<GetOrder>;
 
     /// The future of the service.
     type Future: Future<Output = Result<Self::Service, ExchangeError>>;
@@ -42,7 +42,7 @@ where
         Response = <GetOrder as Request>::Response,
         Error = ExchangeError,
     >,
-    M::Service: ExcService<GetOrder>,
+    M::Service: SendExcService<GetOrder>,
     M::MakeError: Into<ExchangeError>,
 {
     type Service = M::Service;

--- a/exc-make/src/instruments.rs
+++ b/exc-make/src/instruments.rs
@@ -1,4 +1,4 @@
-use exc_service::{ExcService, ExchangeError, Request};
+use exc_service::{ExchangeError, Request, SendExcService};
 use exc_types::SubscribeInstruments;
 use futures::{future::MapErr, TryFutureExt};
 use std::{
@@ -14,7 +14,7 @@ pub struct MakeInstrumentsOptions {}
 /// Make a service to subscribe instruments.
 pub trait MakeInstruments {
     /// Service to subscribe instruments.
-    type Service: ExcService<SubscribeInstruments>;
+    type Service: SendExcService<SubscribeInstruments>;
 
     /// The future of the service.
     type Future: Future<Output = Result<Self::Service, ExchangeError>>;
@@ -42,7 +42,7 @@ where
         Response = <SubscribeInstruments as Request>::Response,
         Error = ExchangeError,
     >,
-    M::Service: ExcService<SubscribeInstruments>,
+    M::Service: SendExcService<SubscribeInstruments>,
     M::MakeError: Into<ExchangeError>,
 {
     type Service = M::Service;

--- a/exc-make/src/orders.rs
+++ b/exc-make/src/orders.rs
@@ -1,4 +1,4 @@
-use exc_service::{ExcService, ExchangeError, Request};
+use exc_service::{ExchangeError, Request, SendExcService};
 use exc_types::SubscribeOrders;
 use futures::{future::MapErr, TryFutureExt};
 use std::{
@@ -14,7 +14,7 @@ pub struct MakeSubscribeOrdersOptions {}
 /// Make a service to subscribe orders.
 pub trait MakeSubscribeOrders {
     /// Service to subscribe orders.
-    type Service: ExcService<SubscribeOrders>;
+    type Service: SendExcService<SubscribeOrders>;
 
     /// The future of the service.
     type Future: Future<Output = Result<Self::Service, ExchangeError>>;
@@ -42,7 +42,7 @@ where
         Response = <SubscribeOrders as Request>::Response,
         Error = ExchangeError,
     >,
-    M::Service: ExcService<SubscribeOrders>,
+    M::Service: SendExcService<SubscribeOrders>,
     M::MakeError: Into<ExchangeError>,
 {
     type Service = M::Service;

--- a/exc-make/src/place.rs
+++ b/exc-make/src/place.rs
@@ -1,4 +1,4 @@
-use exc_service::{ExcService, ExchangeError, Request};
+use exc_service::{ExchangeError, Request, SendExcService};
 use exc_types::PlaceOrder;
 use futures::{future::MapErr, TryFutureExt};
 use std::{
@@ -14,7 +14,7 @@ pub struct MakePlaceOrderOptions {}
 /// Make a service to place orders.
 pub trait MakePlaceOrder {
     /// Service to place orders.
-    type Service: ExcService<PlaceOrder>;
+    type Service: SendExcService<PlaceOrder>;
 
     /// The future of the service.
     type Future: Future<Output = Result<Self::Service, ExchangeError>>;
@@ -42,7 +42,7 @@ where
         Response = <PlaceOrder as Request>::Response,
         Error = ExchangeError,
     >,
-    M::Service: ExcService<PlaceOrder>,
+    M::Service: SendExcService<PlaceOrder>,
     M::MakeError: Into<ExchangeError>,
 {
     type Service = M::Service;

--- a/exc-make/src/tickers.rs
+++ b/exc-make/src/tickers.rs
@@ -1,4 +1,4 @@
-use exc_service::{ExcService, ExchangeError, Request};
+use exc_service::{ExchangeError, Request, SendExcService};
 use exc_types::SubscribeTickers;
 use futures::{future::MapErr, TryFutureExt};
 use std::{
@@ -14,7 +14,7 @@ pub struct MakeTickersOptions {}
 /// Make a service to subscribe tickers.
 pub trait MakeTickers {
     /// Service to subscribe tickers.
-    type Service: ExcService<SubscribeTickers>;
+    type Service: SendExcService<SubscribeTickers>;
 
     /// The future of the service.
     type Future: Future<Output = Result<Self::Service, ExchangeError>>;
@@ -42,7 +42,7 @@ where
         Response = <SubscribeTickers as Request>::Response,
         Error = ExchangeError,
     >,
-    M::Service: ExcService<SubscribeTickers>,
+    M::Service: SendExcService<SubscribeTickers>,
     M::MakeError: Into<ExchangeError>,
 {
     type Service = M::Service;

--- a/exc-service/Cargo.toml
+++ b/exc-service/Cargo.toml
@@ -15,6 +15,10 @@ retry = ["tower/retry", "humantime", "tokio/time", "tracing"]
 limit = ["tower/limit"]
 http = ["hyper"]
 
+# Add [`SendExcSerivce`] which is a [`ExcService`] that is `Send`.
+# as a workaround for https://github.com/rust-lang/rust/issues/20671
+send = []
+
 [dependencies]
 tower = { workspace = true, default-features = false, features = ["util"] }
 futures = { workspace = true }

--- a/exc-service/src/lib.rs
+++ b/exc-service/src/lib.rs
@@ -32,6 +32,9 @@ pub use {
 use self::adapt::{Adapt, AdaptLayer, AdaptService};
 pub use self::error::ExchangeError;
 
+#[cfg(feature = "send")]
+pub use self::traits::send::SendExcService;
+
 /// The core service wrapper of this crate, which implements
 /// [`ExcService<T>`] *if* the request type of the underlying
 /// service implements [`Adaptor<T>`].

--- a/exc-service/src/traits.rs
+++ b/exc-service/src/traits.rs
@@ -6,6 +6,13 @@ use tower::{
     Layer, Service,
 };
 
+use std::{
+    fmt,
+    future::Future,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
 /// Request and Response binding.
 pub trait Request: Sized {
     /// Response type.
@@ -16,10 +23,29 @@ pub trait Request: Sized {
 /// and the error type to be [`ExchangeError`].
 ///
 /// Basically, [`Request`] is just indicating that the input type has a fixed response type.
-pub trait ExcService<R>: Service<R, Response = R::Response, Error = ExchangeError>
+pub trait ExcService<R>
 where
     R: Request,
 {
+    /// The future response value.
+    type Future: Future<Output = Result<R::Response, ExchangeError>>;
+
+    /// See [`Service::poll_ready`] for more details.
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ExchangeError>>;
+
+    /// See [`Service::call`] for more details.
+    fn call(&mut self, req: R) -> Self::Future;
+
+    /// Convert to a [`Service`].
+    fn as_service(&mut self) -> AsService<'_, Self, R>
+    where
+        Self: Sized,
+    {
+        AsService {
+            inner: self,
+            _req: PhantomData,
+        }
+    }
 }
 
 impl<S, R> ExcService<R> for S
@@ -27,6 +53,103 @@ where
     S: Service<R, Response = R::Response, Error = ExchangeError>,
     R: Request,
 {
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ExchangeError>> {
+        Service::<R>::poll_ready(self, cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        Service::<R>::call(self, req)
+    }
+}
+
+/// [`Service`] returns by [`ExcService::as_service`].
+pub struct AsService<'a, S, R> {
+    inner: &'a mut S,
+    _req: PhantomData<R>,
+}
+
+impl<'a, S, R> fmt::Debug for AsService<'a, S, R>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AsService")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<'a, S, R> Service<R> for AsService<'a, S, R>
+where
+    R: Request,
+    S: ExcService<R>,
+{
+    type Response = R::Response;
+
+    type Error = ExchangeError;
+
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ExcService::<R>::poll_ready(self.inner, cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        ExcService::<R>::call(self.inner, req)
+    }
+}
+
+/// [`Service`] returns by [`ExcServiceExt::into_service`].
+pub struct IntoService<S, R> {
+    inner: S,
+    _req: PhantomData<R>,
+}
+
+impl<S, R> fmt::Debug for IntoService<S, R>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntoService")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<S, R> Clone for IntoService<S, R>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _req: PhantomData,
+        }
+    }
+}
+
+impl<S, R> Copy for IntoService<S, R> where S: Copy {}
+
+impl<S, R> Service<R> for IntoService<S, R>
+where
+    R: Request,
+    S: ExcService<R>,
+{
+    type Response = R::Response;
+
+    type Error = ExchangeError;
+
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ExcService::<R>::poll_ready(&mut self.inner, cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        ExcService::<R>::call(&mut self.inner, req)
+    }
 }
 
 /// Extension trait for [`ExcService`].
@@ -34,6 +157,17 @@ pub trait ExcServiceExt<R>: ExcService<R>
 where
     R: Request,
 {
+    /// Convert into a [`Service`].
+    fn into_service(self) -> IntoService<Self, R>
+    where
+        Self: Sized,
+    {
+        IntoService {
+            inner: self,
+            _req: PhantomData,
+        }
+    }
+
     /// Apply a layer of which the result service is still a [`ExcService`].
     fn apply<L, R2>(self, layer: &L) -> L::Service
     where
@@ -57,12 +191,16 @@ where
 
     /// Apply a rate-limit layer to the service.
     #[cfg(feature = "limit")]
-    fn rate_limited(self, num: u64, per: std::time::Duration) -> tower::limit::RateLimit<Self>
+    fn rate_limited(
+        self,
+        num: u64,
+        per: std::time::Duration,
+    ) -> tower::limit::RateLimit<IntoService<Self, R>>
     where
         Self: Sized,
     {
         use tower::limit::RateLimitLayer;
-        self.apply(&RateLimitLayer::new(num, per))
+        self.into_service().apply(&RateLimitLayer::new(num, per))
     }
 
     /// Apply a retry layer to the service.
@@ -70,7 +208,7 @@ where
     fn retry(
         self,
         max_duration: std::time::Duration,
-    ) -> tower::retry::Retry<crate::retry::Always, Self>
+    ) -> tower::retry::Retry<crate::retry::Always, IntoService<Self, R>>
     where
         R: Clone,
         Self: Sized + Clone,
@@ -78,28 +216,31 @@ where
         use crate::retry::Always;
         use tower::retry::RetryLayer;
 
-        self.apply(&RetryLayer::new(Always::with_max_duration(max_duration)))
+        self.into_service()
+            .apply(&RetryLayer::new(Always::with_max_duration(max_duration)))
     }
 
     /// Create a boxed [`ExcService`].
     fn boxed(self) -> BoxExcService<R>
     where
         Self: Sized + Send + 'static,
+        R: Send + 'static,
         Self::Future: Send + 'static,
     {
         BoxExcService {
-            inner: BoxService::new(self),
+            inner: BoxService::new(self.into_service()),
         }
     }
 
     /// Create a boxed [`ExcService`] with [`Clone`].
     fn boxed_clone(&self) -> BoxCloneExcService<R>
     where
+        R: Send + 'static,
         Self: Sized + Clone + Send + 'static,
         Self::Future: Send + 'static,
     {
         BoxCloneExcService {
-            inner: BoxCloneService::new(self.clone()),
+            inner: BoxCloneService::new(self.clone().into_service()),
         }
     }
 }

--- a/exc-service/src/traits/mod.rs
+++ b/exc-service/src/traits/mod.rs
@@ -13,6 +13,10 @@ use std::{
     task::{Context, Poll},
 };
 
+/// Sendable [`ExcService`].
+#[cfg(feature = "send")]
+pub mod send;
+
 /// Request and Response binding.
 pub trait Request: Sized {
     /// Response type.

--- a/exc-service/src/traits/send.rs
+++ b/exc-service/src/traits/send.rs
@@ -10,12 +10,12 @@ use std::{
 };
 
 /// An alias of [`ExcService`] with [`Send`] and `'static` bounds.
-pub trait SendExcService<R>: Send
+pub trait SendExcService<R>: Send + 'static
 where
     R: Request,
 {
     /// The future response value.
-    type Future: Future<Output = Result<R::Response, ExchangeError>>;
+    type Future: Future<Output = Result<R::Response, ExchangeError>> + Send + 'static;
 
     /// See [`Service::poll_ready`] for more details.
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ExchangeError>>;
@@ -48,7 +48,7 @@ where
 
 impl<S, R> SendExcService<R> for S
 where
-    S: ExcService<R> + Send,
+    S: ExcService<R> + Send + 'static,
     R: Request,
     S::Future: Send + 'static,
 {

--- a/exc-service/src/traits/send.rs
+++ b/exc-service/src/traits/send.rs
@@ -1,0 +1,63 @@
+use crate::{ExcService, ExchangeError, Request};
+
+use std::{
+    future::Future,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use super::{AsService, IntoService};
+
+/// An alias of [`ExcService`] with [`Send`] and `'static` bounds.
+pub trait SendExcService<R>: Send
+where
+    R: Request,
+{
+    /// The future response value.
+    type Future: Future<Output = Result<R::Response, ExchangeError>>;
+
+    /// See [`Service::poll_ready`] for more details.
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ExchangeError>>;
+
+    /// See [`Service::call`] for more details.
+    fn call(&mut self, req: R) -> Self::Future;
+
+    /// Convert to a [`Service`].
+    fn as_service(&mut self) -> AsService<'_, Self, R>
+    where
+        Self: Sized,
+    {
+        AsService {
+            inner: self,
+            _req: PhantomData,
+        }
+    }
+
+    /// Convert to a [`Service`].
+    fn into_service(self) -> IntoService<Self, R>
+    where
+        Self: Sized,
+    {
+        IntoService {
+            inner: self,
+            _req: PhantomData,
+        }
+    }
+}
+
+impl<S, R> SendExcService<R> for S
+where
+    S: ExcService<R> + Send,
+    R: Request,
+    S::Future: Send + 'static,
+{
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ExchangeError>> {
+        ExcService::<R>::poll_ready(self, cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        ExcService::<R>::call(self, req)
+    }
+}

--- a/exc-service/src/traits/send.rs
+++ b/exc-service/src/traits/send.rs
@@ -1,12 +1,13 @@
+use tower::Service;
+
 use crate::{ExcService, ExchangeError, Request};
 
 use std::{
+    fmt,
     future::Future,
     marker::PhantomData,
     task::{Context, Poll},
 };
-
-use super::{AsService, IntoService};
 
 /// An alias of [`ExcService`] with [`Send`] and `'static` bounds.
 pub trait SendExcService<R>: Send
@@ -59,5 +60,93 @@ where
 
     fn call(&mut self, req: R) -> Self::Future {
         ExcService::<R>::call(self, req)
+    }
+}
+
+/// [`Service`] returns by [`SendExcService::as_service`].
+pub struct AsService<'a, S, R> {
+    inner: &'a mut S,
+    _req: PhantomData<R>,
+}
+
+impl<'a, S, R> fmt::Debug for AsService<'a, S, R>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AsService")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<'a, S, R> Service<R> for AsService<'a, S, R>
+where
+    R: Request,
+    S: SendExcService<R>,
+{
+    type Response = R::Response;
+
+    type Error = ExchangeError;
+
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        SendExcService::<R>::poll_ready(self.inner, cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        SendExcService::<R>::call(self.inner, req)
+    }
+}
+
+/// [`Service`] returns by [`SendExcService::into_service`].
+pub struct IntoService<S, R> {
+    inner: S,
+    _req: PhantomData<R>,
+}
+
+impl<S, R> fmt::Debug for IntoService<S, R>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntoService")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<S, R> Clone for IntoService<S, R>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _req: PhantomData,
+        }
+    }
+}
+
+impl<S, R> Copy for IntoService<S, R> where S: Copy {}
+
+impl<S, R> Service<R> for IntoService<S, R>
+where
+    R: Request,
+    S: SendExcService<R>,
+{
+    type Response = R::Response;
+
+    type Error = ExchangeError;
+
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        SendExcService::<R>::poll_ready(&mut self.inner, cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        SendExcService::<R>::call(&mut self.inner, req)
     }
 }

--- a/exc/Cargo.toml
+++ b/exc/Cargo.toml
@@ -32,6 +32,7 @@ rustls-tls = [
     "exc-okx?/rustls-tls",
     "exc-binance?/rustls-tls",
 ]
+
 okx = ["exc-okx"]
 okx-prefer-client-id = ["okx", "exc-okx/prefer-client-id"]
 binance = ["exc-binance"]

--- a/exc/src/util/book.rs
+++ b/exc/src/util/book.rs
@@ -20,7 +20,7 @@ where
 {
     /// Subscribe current best bid and ask.
     fn subscribe_bid_ask(&mut self, inst: &str) -> BoxFuture<'_, crate::Result<BidAskStream>> {
-        ServiceExt::oneshot(self, SubscribeBidAsk::new(inst)).boxed()
+        ServiceExt::oneshot(self.as_service(), SubscribeBidAsk::new(inst)).boxed()
     }
 }
 

--- a/exc/src/util/fetch_candles.rs
+++ b/exc/src/util/fetch_candles.rs
@@ -33,8 +33,11 @@ where
         start: Bound<OffsetDateTime>,
         end: Bound<OffsetDateTime>,
     ) -> BoxFuture<'_, crate::Result<CandleStream>> {
-        ServiceExt::<QueryCandles>::oneshot(self, QueryCandles::new(inst, period, (start, end)))
-            .boxed()
+        ServiceExt::<QueryCandles>::oneshot(
+            self.as_service(),
+            QueryCandles::new(inst, period, (start, end)),
+        )
+        .boxed()
     }
 }
 

--- a/exc/src/util/instrument.rs
+++ b/exc/src/util/instrument.rs
@@ -28,7 +28,7 @@ where
         tag: &str,
     ) -> BoxFuture<'_, crate::Result<InstrumentStream>> {
         ServiceExt::<SubscribeInstruments>::oneshot(
-            self,
+            self.as_service(),
             SubscribeInstruments { tag: Str::new(tag) },
         )
         .boxed()
@@ -48,8 +48,11 @@ where
 {
     /// Fetch instruments filter by a given tag.
     fn fetch_instruments(&mut self, tag: &str) -> BoxFuture<'_, crate::Result<InstrumentStream>> {
-        ServiceExt::<FetchInstruments>::oneshot(self, FetchInstruments { tag: Str::new(tag) })
-            .boxed()
+        ServiceExt::<FetchInstruments>::oneshot(
+            self.as_service(),
+            FetchInstruments { tag: Str::new(tag) },
+        )
+        .boxed()
     }
 }
 

--- a/exc/src/util/reconnect.rs
+++ b/exc/src/util/reconnect.rs
@@ -28,7 +28,7 @@ where
         Self: Sized,
     {
         let mut state = State::Init;
-        ServiceExt::<Reconnect>::call_all(self, iter([Reconnect, Reconnect]))
+        ServiceExt::<Reconnect>::call_all(self.as_service(), iter([Reconnect, Reconnect]))
             .fold(Ok(()), move |res, x| match state {
                 State::Init => {
                     state = State::Reconnect;

--- a/exc/src/util/subscribe_tickers.rs
+++ b/exc/src/util/subscribe_tickers.rs
@@ -19,6 +19,7 @@ where
 {
     /// Subscribe tickers.
     fn subscribe_tickers(&mut self, inst: &str) -> BoxFuture<'_, crate::Result<TickerStream>> {
-        ServiceExt::<SubscribeTickers>::oneshot(self, SubscribeTickers::new(inst)).boxed()
+        ServiceExt::<SubscribeTickers>::oneshot(self.as_service(), SubscribeTickers::new(inst))
+            .boxed()
     }
 }

--- a/exc/src/util/trade.rs
+++ b/exc/src/util/trade.rs
@@ -16,6 +16,6 @@ where
     S::Future: Send,
 {
     fn subscribe_trades(&mut self, inst: &str) -> BoxFuture<'_, crate::Result<TradeStream>> {
-        ServiceExt::oneshot(self, SubscribeTrades::new(inst)).boxed()
+        ServiceExt::oneshot(self.as_service(), SubscribeTrades::new(inst)).boxed()
     }
 }


### PR DESCRIPTION
These are workarounds to simplify the trait bounds of [`MakeExchange`]. See https://github.com/rust-lang/rust/issues/20671 for more information.