### PR TITLE
okx: do not use uly to build symbol

### DIFF
--- a/examples/examples/okx_subscribe_instruments.rs
+++ b/examples/examples/okx_subscribe_instruments.rs
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
         .ws_request_timeout(Duration::from_secs(5))
         .ws_connection_timeout(Duration::from_secs(5))
         .connect_exc();
-    let handles = ["SPOT", "FUTURES", "SWAP"]
+    let handles = ["SPOT", "FUTURES", "SWAP", "OPTION"]
         .iter()
         .map(|tag| {
             let tag = tag.to_string();

--- a/exc-okx/src/http/types/adaptations/instruments.rs
+++ b/exc-okx/src/http/types/adaptations/instruments.rs
@@ -18,7 +18,7 @@ impl Adaptor<FetchInstruments> for HttpRequest {
         let (tag, params) = parse_inst_tag(&req.tag)?;
         let req = Self::Get(Get::Instruments(Instruments {
             inst_type: tag,
-            inst_family: params.family,
+            inst_family: params.inst_family,
             uly: params.uly,
             ..Default::default()
         }));

--- a/exc-okx/src/utils/inst_tag.rs
+++ b/exc-okx/src/utils/inst_tag.rs
@@ -5,9 +5,11 @@ use crate::error::OkxError;
 
 /// Instrument Tag Params.
 #[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Params {
     /// Instrument family.
-    pub family: Option<Str>,
+    #[serde(alias = "family")]
+    pub inst_family: Option<Str>,
     /// Instrument underlying.
     pub uly: Option<Str>,
 }

--- a/exc-okx/src/websocket/types/messages/event/instrument.rs
+++ b/exc-okx/src/websocket/types/messages/event/instrument.rs
@@ -1,7 +1,7 @@
 use exc_core::{
     symbol::ExcSymbol,
     types::instrument::{Attributes, InstrumentMeta},
-    Asset, ParseAssetError, Str,
+    Asset, Str,
 };
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -97,23 +97,25 @@ impl OkxInstrumentMeta {
                 &contract.ct_val_ccy,
                 &contract.settle_ccy,
             )),
-            Self::Option(OptionMeta { common, .. }) => {
-                let mut parts = common.inst_id.split('-');
-                let base = parts
-                    .next()
-                    .map(|s| s.parse())
-                    .transpose()
-                    .map_err(|err: ParseAssetError| OkxError::ParseSymbol(err.into()))?;
-                let quote = parts
-                    .next()
-                    .map(|s| s.parse())
-                    .transpose()
-                    .map_err(|err: ParseAssetError| OkxError::ParseSymbol(err.into()))?;
+            Self::Option(OptionMeta {
+                common, contract, ..
+            }) => {
+                let mut parts = common.inst_id.split('-').skip(2);
                 let date = parts.next();
                 let price = parts.next();
                 parts.next().and_then(|ty| match ty {
-                    "c" | "C" => ExcSymbol::call_with_str(&base?, &quote?, date?, price?),
-                    "p" | "P" => ExcSymbol::put_with_str(&base?, &quote?, date?, price?),
+                    "c" | "C" => ExcSymbol::call_with_str(
+                        &contract.ct_val_ccy,
+                        &contract.settle_ccy,
+                        date?,
+                        price?,
+                    ),
+                    "p" | "P" => ExcSymbol::put_with_str(
+                        &contract.ct_val_ccy,
+                        &contract.settle_ccy,
+                        date?,
+                        price?,
+                    ),
                     _ => None,
                 })
             }


### PR DESCRIPTION
Rollback the option symbol format to `O{DATE}{C/P}{PRICE}:{BASE}-{QUOTE}`, not `O{DATE}{C/P}{PRICE}:{underlying}`