### PR TITLE
Add missing exc features to `examples`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,7 +6,15 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-exc = { workspace = true, features = ["okx", "binance", "instrument", "poll"] }
+exc = { workspace = true, features = [
+    "okx",
+    "binance",
+    "instrument",
+    "poll",
+    "rustls-tls",
+    "limit",
+    "fetch-candles",
+] }
 exc-okx = { workspace = true }
 exc-binance = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing"] }

--- a/examples/examples/binance_reconnect.rs
+++ b/examples/examples/binance_reconnect.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
             tokio::spawn(async move {
                 loop {
                     tracing::info!("{inst}");
-                    match { client.subscribe_tickers(inst).await } {
+                    match client.subscribe_tickers(inst).await {
                         Ok(mut stream) => {
                             while let Some(c) = stream.next().await {
                                 match c {

--- a/examples/examples/binance_streams.rs
+++ b/examples/examples/binance_streams.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
             tokio::spawn(async move {
                 loop {
                     tracing::info!("{inst}");
-                    match { client.subscribe_tickers(inst).await } {
+                    match client.subscribe_tickers(inst).await {
                         Ok(mut stream) => {
                             while let Some(c) = stream.next().await {
                                 match c {

--- a/examples/examples/okx_reconnect.rs
+++ b/examples/examples/okx_reconnect.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
             tokio::spawn(async move {
                 loop {
                     tracing::info!("{inst}");
-                    match { client.subscribe_tickers(inst).await } {
+                    match client.subscribe_tickers(inst).await {
                         Ok(mut stream) => {
                             while let Some(c) = stream.next().await {
                                 match c {

--- a/examples/examples/okx_streams.rs
+++ b/examples/examples/okx_streams.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
             tokio::spawn(async move {
                 loop {
                     tracing::info!("{inst}");
-                    match { client.subscribe_tickers(inst).await } {
+                    match client.subscribe_tickers(inst).await {
                         Ok(mut stream) => {
                             while let Some(c) = stream.next().await {
                                 match c {

--- a/exc-binance/src/http/response/candle.rs
+++ b/exc-binance/src/http/response/candle.rs
@@ -6,6 +6,7 @@ use crate::http::error::RestError;
 use super::Data;
 
 /// Candle in list form.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct Candle(
     /// Open time.


### PR DESCRIPTION
We disabled the default features of the workspace version of `exc`, which cause the examples crate to fail to compile (#97). Adding back those required features will help.